### PR TITLE
Use the right class properties in Tab ad Input

### DIFF
--- a/src/components/Cards/TasksCard.jsx
+++ b/src/components/Cards/TasksCard.jsx
@@ -48,9 +48,9 @@ class TasksCard extends React.Component {
               <Tab
                 classes={{
                   wrapper: classes.tabWrapper,
-                  rootLabelIcon: classes.labelIcon,
+                  labelIcon: classes.labelIcon,
                   label: classes.label,
-                  rootInheritSelected: classes.rootInheritSelected
+                  textColorInheritSelected: classes.textColorInheritSelected
                 }}
                 icon={<BugReport className={classes.tabIcon} />}
                 label={"Bugs"}
@@ -58,9 +58,9 @@ class TasksCard extends React.Component {
               <Tab
                 classes={{
                   wrapper: classes.tabWrapper,
-                  rootLabelIcon: classes.labelIcon,
+                  labelIcon: classes.labelIcon,
                   label: classes.label,
-                  rootInheritSelected: classes.rootInheritSelected
+                  textColorInheritSelected: classes.textColorInheritSelected
                 }}
                 icon={<Code className={classes.tabIcon} />}
                 label={"Website"}
@@ -68,9 +68,9 @@ class TasksCard extends React.Component {
               <Tab
                 classes={{
                   wrapper: classes.tabWrapper,
-                  rootLabelIcon: classes.labelIcon,
+                  labelIcon: classes.labelIcon,
                   label: classes.label,
-                  rootInheritSelected: classes.rootInheritSelected
+                  textColorInheritSelected: classes.textColorInheritSelected
                 }}
                 icon={<Cloud className={classes.tabIcon} />}
                 label={"Server"}

--- a/src/components/CustomInput/CustomInput.jsx
+++ b/src/components/CustomInput/CustomInput.jsx
@@ -48,8 +48,7 @@ function CustomInput({ ...props }) {
         classes={{
           root: marginTop,
           disabled: classes.disabled,
-          underline: classes.underline,
-          inkbar: inkbarClasses
+          underline: cx(classes.underline, inkbarClasses),
         }}
         id={id}
         {...inputProps}

--- a/src/variables/styles/tasksCardStyle.jsx
+++ b/src/variables/styles/tasksCardStyle.jsx
@@ -74,7 +74,7 @@ const tasksCardStyle = theme => ({
     fontWeight: "400",
     marginLeft: "-10px"
   },
-  rootInheritSelected: {
+  textColorInheritSelected: {
     backgroundColor: "rgba(255, 255, 255, 0.2)",
     transition: "background-color .1s .2s"
   }


### PR DESCRIPTION
Those properties doesn't exist in the original code, just in their
`.d.ts` counterparts. Because of that the template was failing
to run in a custom `webpack` environment. Don't know actually
why it was working in `react-scripts start`.

Fix https://github.com/creativetimofficial/material-dashboard-react/issues/11