### PR TITLE
Update material-ui to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "dependencies": {
     "chartist": "^0.10.1",
     "classnames": "^2.2.5",
-    "material-ui": "1.0.0-beta.34",
-    "material-ui-icons": "1.0.0-beta.17",
+    "material-ui": "^1.0.0-beta.40",
+    "material-ui-icons": "^1.0.0-beta.36",
     "npm-run-all": "^4.1.1",
     "perfect-scrollbar": "^1.3.0",
     "react": "^16.2.0",

--- a/src/components/Cards/TasksCard.jsx
+++ b/src/components/Cards/TasksCard.jsx
@@ -38,11 +38,11 @@ class TasksCard extends React.Component {
           action={
             <Tabs
               classes={{
-                flexContainer: classes.tabsContainer
+                flexContainer: classes.tabsContainer,
+                indicator: classes.displayNone,
               }}
               value={this.state.value}
               onChange={this.handleChange}
-              indicatorClassName={classes.displayNone}
               textColor="inherit"
             >
               <Tab

--- a/src/views/Dashboard/Dashboard.jsx
+++ b/src/views/Dashboard/Dashboard.jsx
@@ -47,7 +47,7 @@ class Dashboard extends React.Component {
   render() {
     return (
       <div>
-        <Grid container>
+        <Grid container spacing={16}>
           <ItemGrid xs={12} sm={6} md={3}>
             <StatsCard
               icon={ContentCopy}
@@ -91,7 +91,7 @@ class Dashboard extends React.Component {
             />
           </ItemGrid>
         </Grid>
-        <Grid container>
+        <Grid container spacing={16}>
           <ItemGrid xs={12} sm={12} md={4}>
             <ChartCard
               chart={
@@ -158,7 +158,7 @@ class Dashboard extends React.Component {
             />
           </ItemGrid>
         </Grid>
-        <Grid container>
+        <Grid container spacing={16}>
           <ItemGrid xs={12} sm={12} md={6}>
             <TasksCard />
           </ItemGrid>

--- a/src/views/Icons/Icons.jsx
+++ b/src/views/Icons/Icons.jsx
@@ -8,7 +8,7 @@ import iconsStyle from "variables/styles/iconsStyle";
 
 function Icons({ ...props }) {
   return (
-    <Grid container>
+    <Grid container spacing={16}>
       <ItemGrid xs={12} sm={12} md={12}>
         <RegularCard
           plainCard

--- a/src/views/Notifications/Notifications.jsx
+++ b/src/views/Notifications/Notifications.jsx
@@ -58,7 +58,7 @@ class Notifications extends React.Component {
         }
         content={
           <div>
-            <Grid container>
+            <Grid container spacing={16}>
               <ItemGrid xs={12} sm={12} md={6}>
                 <h5>Notifications Style</h5>
                 <br />
@@ -131,7 +131,7 @@ class Notifications extends React.Component {
             </Grid>
             <br />
             <br />
-            <Grid container justify="center">
+            <Grid container justify="center" spacing={16}>
               <ItemGrid xs={12} sm={12} md={6} style={{ textAlign: "center" }}>
                 <h5>
                   Notifications Places
@@ -139,9 +139,9 @@ class Notifications extends React.Component {
                 </h5>
               </ItemGrid>
             </Grid>
-            <Grid container justify="center">
+            <Grid container justify="center" spacing={16}>
               <ItemGrid xs={12} sm={12} md={10} lg={8}>
-                <Grid container>
+                <Grid container spacing={16}>
                   <ItemGrid xs={12} sm={12} md={4}>
                     <Button
                       fullWidth
@@ -199,9 +199,9 @@ class Notifications extends React.Component {
                 </Grid>
               </ItemGrid>
             </Grid>
-            <Grid container justify={"center"}>
+            <Grid container justify={"center"} spacing={16}>
               <ItemGrid xs={12} sm={12} md={10} lg={8}>
-                <Grid container>
+                <Grid container spacing={16}>
                   <ItemGrid xs={12} sm={12} md={4}>
                     <Button
                       fullWidth

--- a/src/views/TableList/TableList.jsx
+++ b/src/views/TableList/TableList.jsx
@@ -5,7 +5,7 @@ import { RegularCard, Table, ItemGrid } from "components";
 
 function TableList({ ...props }) {
   return (
-    <Grid container>
+    <Grid container spacing={16}>
       <ItemGrid xs={12} sm={12} md={12}>
         <RegularCard
           cardTitle="Simple Table"

--- a/src/views/UserProfile/UserProfile.jsx
+++ b/src/views/UserProfile/UserProfile.jsx
@@ -14,14 +14,14 @@ import avatar from "assets/img/faces/marc.jpg";
 function UserProfile({ ...props }) {
   return (
     <div>
-      <Grid container>
+      <Grid container spacing={16}>
         <ItemGrid xs={12} sm={12} md={8}>
           <RegularCard
             cardTitle="Edit Profile"
             cardSubtitle="Complete your profile"
             content={
               <div>
-                <Grid container>
+                <Grid container spacing={16}>
                   <ItemGrid xs={12} sm={12} md={5}>
                     <CustomInput
                       labelText="Company (disabled)"
@@ -53,7 +53,7 @@ function UserProfile({ ...props }) {
                     />
                   </ItemGrid>
                 </Grid>
-                <Grid container>
+                <Grid container spacing={16}>
                   <ItemGrid xs={12} sm={12} md={6}>
                     <CustomInput
                       labelText="First Name"
@@ -73,7 +73,7 @@ function UserProfile({ ...props }) {
                     />
                   </ItemGrid>
                 </Grid>
-                <Grid container>
+                <Grid container spacing={16}>
                   <ItemGrid xs={12} sm={12} md={4}>
                     <CustomInput
                       labelText="City"
@@ -102,7 +102,7 @@ function UserProfile({ ...props }) {
                     />
                   </ItemGrid>
                 </Grid>
-                <Grid container>
+                <Grid container spacing={16}>
                   <ItemGrid xs={12} sm={12} md={12}>
                     <InputLabel style={{ color: "#AAAAAA" }}>
                       About me


### PR DESCRIPTION
Update mui and fix some breaking changes from it. Those can be found here: https://github.com/mui-org/material-ui/releases

Some notes:

1) Because of the change in the `Grid` to have 0 spacing by default, I put a `spacing={16}` in all `Grid` containers to avoid breaking the theme and maintaining the same look and feel.

2) With this update, there are some class properties that broke, even with `react-scripts`. Those were fixed in https://github.com/creativetimofficial/material-dashboard-react/pull/12 . If this PR is to be merged, that one should be merged first.