### PR TITLE
Fixed popper typos (spelled as 💩  :D )

### DIFF
--- a/src/assets/jss/material-dashboard-react/dropdownStyle.jsx
+++ b/src/assets/jss/material-dashboard-react/dropdownStyle.jsx
@@ -32,7 +32,7 @@ const dropdownStyle = theme => ({
   popperClose: {
     pointerEvents: "none"
   },
-  pooperResponsive: {
+  popperResponsive: {
     [theme.breakpoints.down("md")]: {
       zIndex: "1640",
       position: "static",
@@ -46,7 +46,7 @@ const dropdownStyle = theme => ({
       color: "black"
     }
   },
-  pooperNav: {
+  popperNav: {
     [theme.breakpoints.down("sm")]: {
       position: "static !important",
       left: "unset !important",

--- a/src/components/Header/HeaderLinks.jsx
+++ b/src/components/Header/HeaderLinks.jsx
@@ -98,7 +98,7 @@ class HeaderLinks extends React.Component {
             className={
               classNames({ [classes.popperClose]: !open }) +
               " " +
-              classes.pooperNav
+              classes.popperNav
             }
           >
             {({ TransitionProps, placement }) => (


### PR DESCRIPTION
Fixed popper typos spelled with double o like  pooper 💩 rather than popper. It helps when you grep the codebase.