### PR TITLE
Resolve a dependencies conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "history": "5.0.0",
     "perfect-scrollbar": "1.5.1",
     "prop-types": "15.7.2",
-    "react": "17.0.2",
+    "react": "16.14.0",
     "react-chartist": "0.14.4",
-    "react-dom": "17.0.2",
+    "react-dom": "16.14.0",
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
     "react-swipeable-views": "0.13.9"


### PR DESCRIPTION
# Issue
https://github.com/creativetimofficial/material-dashboard-react/issues/159

# What 
Downgrade React version 17 to 16

# Why
React 17 conflict other dependency `react-swipeable-views` which needs React under 16.
